### PR TITLE
Cleanup Cayenne dependencies

### DIFF
--- a/link-rest/src/main/java/com/nhl/link/rest/meta/DefaultLrEntity.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/DefaultLrEntity.java
@@ -19,11 +19,15 @@ public class DefaultLrEntity<T> implements LrEntity<T> {
 	// TODO: ensure name uniquness between all types of properties
 
 	public DefaultLrEntity(Class<T> type) {
+		this(type, type.getSimpleName());
+	}
+
+	public DefaultLrEntity(Class<T> type, String name) {
 		this.type = type;
 		this.relationships = new HashMap<>();
 		this.attributes = new HashMap<>();
 		this.ids = new HashMap<>();
-		this.name = type.getSimpleName();
+		this.name = name;
 	}
 
 	@Override

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/LrJoin.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/LrJoin.java
@@ -1,0 +1,17 @@
+package com.nhl.link.rest.meta;
+
+/**
+ * @since 2.5
+ */
+public interface LrJoin {
+
+    /**
+     * @since 2.5
+     */
+    String getSourceColumnName();
+
+    /**
+     * @since 2.5
+     */
+    String getTargetColumnName();
+}

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/LrPersistentEntity.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/LrPersistentEntity.java
@@ -2,16 +2,12 @@ package com.nhl.link.rest.meta;
 
 import java.util.Collection;
 
-import org.apache.cayenne.map.ObjEntity;
-
 /**
  * An entity model shared across LinkRest stack.
  * 
  * @since 1.12
  */
 public interface LrPersistentEntity<T> extends LrEntity<T> {
-
-	ObjEntity getObjEntity();
 
 	LrPersistentAttribute getPersistentAttribute(String name);
 

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/LrPersistentRelationship.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/LrPersistentRelationship.java
@@ -1,22 +1,26 @@
 package com.nhl.link.rest.meta;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.nhl.link.rest.LrObjectId;
-
-import java.util.Map;
+import java.util.Collection;
 
 /**
  * @since 1.12
  */
 public interface LrPersistentRelationship extends LrRelationship {
 
+	/**
+     * @since 2.5
+     */
 	boolean isToDependentEntity();
 
+	/**
+     * @since 2.5
+     */
 	boolean isPrimaryKey();
 
+	/**
+     * @since 2.5
+     */
+	Collection<LrJoin> getJoins();
+
 //	LrPersistentRelationship getReverseRelationship(); // ???
-
-	Map<String, Object> extractId(LrObjectId id); // TODO: move this to a separate place?
-
-	Map<String, Object> extractId(JsonNode id); // TODO: move this to a separate place?
 }

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneEntityCompiler.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneEntityCompiler.java
@@ -135,15 +135,7 @@ public class CayenneEntityCompiler implements LrEntityCompiler {
 
 			Class<?> targetEntityType = resolver.getClassDescriptor(r.getTargetEntityName()).getObjectClass();
 			LrEntity<?> targetEntity = dataMap.getEntity(targetEntityType);
-
-			// take last element from list of db relationships
-			// in order to behave correctly if
-			// db entities are connected through intermediate tables
-			DbRelationship targetRelationship = dbRelationshipsList.get(dbRelationshipsList.size() - 1);
-			int targetJdbcType = targetRelationship.getJoins().get(0).getTarget().getType();
-			Class<?> type = getJavaTypeForTypeName(TypesMapping.getJavaBySqlType(targetJdbcType));
-
-			LrRelationship lrRelationship = new CayenneLrRelationship(r, targetEntity, converterFactory.converter(type));
+			LrRelationship lrRelationship = new CayenneLrRelationship(r, targetEntity);
 			lrEntity.addRelationship(lrRelationship);
 		}
 

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneEntityCompiler.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneEntityCompiler.java
@@ -105,16 +105,15 @@ public class CayenneEntityCompiler implements LrEntityCompiler {
 		LOGGER.debug("compiling Cayenne entity for type: " + type);
 
 		ObjEntity objEntity = resolver.getObjEntity(type);
-		CayenneLrEntity<T> lrEntity = new CayenneLrEntity<>(type, objEntity);
-		loadCayenneEntity(lrEntity, dataMap);
+		CayenneLrEntity<T> lrEntity = new CayenneLrEntity<>(type, objEntity.getName());
+		loadCayenneEntity(lrEntity, objEntity, dataMap);
 		loadAnnotatedProperties(lrEntity, dataMap);
 		loadOverlays(lrEntity);
 		return lrEntity;
 	}
 
-	protected <T> void loadCayenneEntity(CayenneLrEntity<T> lrEntity, LrDataMap dataMap) {
+	protected <T> void loadCayenneEntity(CayenneLrEntity<T> lrEntity, ObjEntity objEntity, LrDataMap dataMap) {
 
-		ObjEntity objEntity = lrEntity.getObjEntity();
 		for (ObjAttribute a : objEntity.getAttributes()) {
 			Class<?> type = getJavaTypeForTypeName(a.getType());
 			CayenneLrAttribute lrAttribute = new CayenneLrAttribute(a, type);

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneLrEntity.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/cayenne/CayenneLrEntity.java
@@ -1,37 +1,23 @@
 package com.nhl.link.rest.meta.cayenne;
 
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import org.apache.cayenne.map.ObjEntity;
-
 import com.nhl.link.rest.meta.DefaultLrEntity;
 import com.nhl.link.rest.meta.LrPersistentAttribute;
 import com.nhl.link.rest.meta.LrPersistentEntity;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * @since 1.12
  */
 public class CayenneLrEntity<T> extends DefaultLrEntity<T> implements LrPersistentEntity<T> {
 
-	private ObjEntity objEntity;
 	private Map<String, LrPersistentAttribute> persistentAttributes;
 
-	public CayenneLrEntity(Class<T> type, ObjEntity objEntity) {
-		super(type);
-		this.objEntity = objEntity;
+	public CayenneLrEntity(Class<T> type, String name) {
+		super(type, name);
 		this.persistentAttributes = new HashMap<>();
-	}
-
-	@Override
-	public String getName() {
-		return objEntity.getName();
-	}
-
-	@Override
-	public ObjEntity getObjEntity() {
-		return objEntity;
 	}
 
 	@Override

--- a/link-rest/src/main/java/com/nhl/link/rest/meta/compiler/LazyLrPersistentEntity.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/meta/compiler/LazyLrPersistentEntity.java
@@ -4,7 +4,6 @@ import com.nhl.link.rest.meta.LrAttribute;
 import com.nhl.link.rest.meta.LrPersistentAttribute;
 import com.nhl.link.rest.meta.LrPersistentEntity;
 import com.nhl.link.rest.meta.LrRelationship;
-import org.apache.cayenne.map.ObjEntity;
 
 import java.util.Collection;
 import java.util.function.Supplier;
@@ -19,11 +18,6 @@ public class LazyLrPersistentEntity<T> extends BaseLazyLrEntity<T, LrPersistentE
     public LazyLrPersistentEntity(Class<T> type, Supplier<LrPersistentEntity<T>> delegateSupplier) {
         super(delegateSupplier);
         this.type = type;
-    }
-
-    @Override
-    public ObjEntity getObjEntity() {
-        return getDelegate().getObjEntity();
     }
 
     @Override

--- a/link-rest/src/main/java/com/nhl/link/rest/runtime/processor/update/ApplyUpdateServerParamsStage.java
+++ b/link-rest/src/main/java/com/nhl/link/rest/runtime/processor/update/ApplyUpdateServerParamsStage.java
@@ -2,6 +2,7 @@ package com.nhl.link.rest.runtime.processor.update;
 
 import com.nhl.link.rest.EntityParent;
 import com.nhl.link.rest.EntityUpdate;
+import com.nhl.link.rest.LrObjectId;
 import com.nhl.link.rest.ResourceEntity;
 import com.nhl.link.rest.annotation.listener.UpdateServerParamsApplied;
 import com.nhl.link.rest.meta.LrEntity;
@@ -15,6 +16,7 @@ import com.nhl.link.rest.runtime.meta.IMetadataService;
 
 import java.lang.annotation.Annotation;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 public class ApplyUpdateServerParamsStage<T> extends BaseLinearProcessingStage<UpdateContext<T>, T> {
@@ -88,11 +90,18 @@ public class ApplyUpdateServerParamsStage<T> extends BaseLinearProcessingStage<U
 				LrPersistentRelationship r = (LrPersistentRelationship) fromParent;
 				if (r.isToDependentEntity()) {
 					for (EntityUpdate<T> u : context.getUpdates()) {
-						u.getOrCreateId().putAll(r.extractId(parent.getId()));
+						u.getOrCreateId().putAll(extractRelatedId(r, parent.getId()));
 					}
 				}
 			}
 		}
+	}
+
+	private Map<String, Object> extractRelatedId(LrPersistentRelationship relationship, LrObjectId objectId) {
+		return relationship.getJoins().stream()
+				.collect(HashMap::new,
+						(m, j) -> m.put(j.getTargetColumnName(), objectId.get(j.getSourceColumnName())),
+						Map::putAll);
 	}
 
 	private LrRelationship relationshipFromParent(UpdateContext<?> context) {

--- a/link-rest/src/test/java/com/nhl/link/rest/runtime/constraints/ConstraintsHandlerWithDefaultsTest.java
+++ b/link-rest/src/test/java/com/nhl/link/rest/runtime/constraints/ConstraintsHandlerWithDefaultsTest.java
@@ -42,12 +42,10 @@ public class ConstraintsHandlerWithDefaultsTest extends TestWithCayenneMapping {
 		ObjEntity e2 = runtime.getChannel().getEntityResolver().getObjEntity(E2.class);
 
 		lre1 = mock(LrPersistentEntity.class);
-		when(lre1.getObjEntity()).thenReturn(e1);
 		when(lre1.getType()).thenReturn(E1.class);
 		when(lre1.getName()).thenReturn(e1.getName());
 
 		lre2 = mock(LrPersistentEntity.class);
-		when(lre2.getObjEntity()).thenReturn(e2);
 		when(lre2.getType()).thenReturn(E2.class);
 		when(lre2.getName()).thenReturn(e2.getName());
 

--- a/link-rest/src/test/java/com/nhl/link/rest/runtime/meta/MetadataServiceTest.java
+++ b/link-rest/src/test/java/com/nhl/link/rest/runtime/meta/MetadataServiceTest.java
@@ -1,15 +1,14 @@
 package com.nhl.link.rest.runtime.meta;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertSame;
-
-import org.junit.Test;
-
 import com.nhl.link.rest.it.fixture.cayenne.E4;
 import com.nhl.link.rest.it.fixture.cayenne.E5;
 import com.nhl.link.rest.meta.LrPersistentEntity;
 import com.nhl.link.rest.unit.TestWithCayenneMapping;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
 
 public class MetadataServiceTest extends TestWithCayenneMapping {
 
@@ -21,8 +20,7 @@ public class MetadataServiceTest extends TestWithCayenneMapping {
 		assertEquals("E4", e4.getName());
 		assertSame(E4.class, e4.getType());
 
-		assertNotNull(e4.getObjEntity());
-		assertEquals("E4", e4.getObjEntity().getName());
+		assertEquals("E4", e4.getName());
 
 		assertEquals(7, e4.getPersistentAttributes().size());
 		assertEquals(0, e4.getRelationships().size());
@@ -39,8 +37,7 @@ public class MetadataServiceTest extends TestWithCayenneMapping {
 		assertEquals("E5", e5.getName());
 		assertSame(E5.class, e5.getType());
 
-		assertNotNull(e5.getObjEntity());
-		assertEquals("E5", e5.getObjEntity().getName());
+		assertEquals("E5", e5.getName());
 
 		assertEquals(2, e5.getPersistentAttributes().size());
 		assertEquals(2, e5.getRelationships().size());


### PR DESCRIPTION
@andrus , please review

At first I've added a visitor method
```java
interface LrPersistentRelationship {
  void visitJoins(JoinVisitor visitor);

  @FunctionalInterface
  interface JoinVisitor {
    void visitJoin(String sourceColumnName, String targetColumnName);
  }
}
```

But then decided to change it to
```java
interface LrPersistentRelationship {
  Collection<LrJoin> getJoins();
}

interface LrJoin {
  String getSourceColumnName();
  String getTargetColumnName(); 
}
```

Both approaches have their pros: visitor method does not require exposing the join abstraction outside of LrPersistentRelationship, while a collection is more pragmatical. So I wanted to check with you if it'd be OK to add something like LrJoin.