### PR TITLE
#327 Code-first approach. Implemented maven plugin to generate swagger definition during build time. 

### DIFF
--- a/link-rest-base/pom.xml
+++ b/link-rest-base/pom.xml
@@ -52,6 +52,11 @@
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>io.swagger.core.v3</groupId>
+            <artifactId>swagger-annotations</artifactId>
+            <version>2.0.0-rc4</version>
+        </dependency>
 
     </dependencies>
 

--- a/link-rest-base/src/main/java/com/nhl/link/rest/protocol/CayenneExp.java
+++ b/link-rest-base/src/main/java/com/nhl/link/rest/protocol/CayenneExp.java
@@ -1,5 +1,9 @@
 package com.nhl.link.rest.protocol;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -11,10 +15,16 @@ import static java.util.Arrays.asList;
  *
  * @since 2.13
  */
+@Schema(name="CayenneExp", description="Cayenne defines a simple yet powerful object-based expression language. " +
+        "Cayenne expressions are database independent and are used as query qualifiers and orderings " +
+        "and also to perform in-memory evaluation with DataObjects.")
 public class CayenneExp {
 
+    @Schema(required = true, example = "name = 'yyy'")
     private String exp;
+
     private Map<String, Object> params;
+
     private List<Object> inPositionParams;
 
     public CayenneExp(String exp) {

--- a/link-rest-swagger-codefirst-test/pom.xml
+++ b/link-rest-swagger-codefirst-test/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>com.nhl.link.rest</groupId>
+        <artifactId>link-rest-parent</artifactId>
+        <version>2.13-SNAPSHOT</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <groupId>com.nhl.link.rest.swagger</groupId>
+    <artifactId>link-rest-swagger-codefirst-test</artifactId>
+    <name>link-rest-swagger-codefirst-test: Integration tests of Swagger code-first approach</name>
+    <description>Integration tests of Swagger code-first approach</description>
+
+    <dependencies>
+        <!-- required runtime dependencies -->
+        <dependency>
+            <groupId>com.nhl.link.rest</groupId>
+            <artifactId>link-rest</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.nhl.link.rest.swagger</groupId>
+                <artifactId>link-rest-swagger-codefirst</artifactId>
+                <version>${project.version}</version>
+                <configuration>
+                    <info>
+                        <title>Swagger Maven Plugin to implement Code-First Approach</title>
+                        <version>1</version>
+                        <description>This is a sample for link-rest-swagger-codefirst plugin</description>
+                        <termsOfService>
+                            http://www.github.com/nhl/link-rest
+                        </termsOfService>
+                        <contact>
+                            <email></email>
+                            <name></name>
+                            <url></url>
+                        </contact>
+                        <license>
+                            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
+                            <name>Apache 2.0</name>
+                        </license>
+                    </info>
+                    <resourceSources>
+                        <resourceSource>
+                            <srcClasses></srcClasses>
+                            <srcPackages></srcPackages>
+                            <outputName></outputName>
+                            <outputFormats></outputFormats>
+                        </resourceSource>
+                    </resourceSources>
+                    <componentSources>
+                        <componentSource>
+                            <srcParameters>
+                                <srcParameter>com.nhl.link.rest.protocol.CayenneExp</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Exclude</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Include</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.MapBy</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Sort</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Limit</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Start</srcParameter>
+                                <srcParameter>com.nhl.link.rest.protocol.Dir</srcParameter>
+                            </srcParameters>
+                            <srcSchemas></srcSchemas>
+                            <outputName>${project.basedir}/protocol</outputName>
+                            <outputFormats></outputFormats>
+                        </componentSource>
+                        <componentSource>
+                            <srcParameters></srcParameters>
+                            <srcSchemas>
+                                <srcSchema>com.nhl.link.rest.it.fixture.cayenne.E1</srcSchema>
+                                <srcSchema>com.nhl.link.rest.it.fixture.cayenne.E2</srcSchema>
+                                <srcSchema>com.nhl.link.rest.it.fixture.cayenne.E3</srcSchema>
+                            </srcSchemas>
+                            <outputName>${project.basedir}/schema</outputName>
+                            <outputFormats></outputFormats>
+                        </componentSource>
+                    </componentSources>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>compile</phase>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                    </execution>
+                </executions>
+
+                <dependencies>
+                    <dependency>
+                        <groupId>com.nhl.link.rest.swagger</groupId>
+                        <artifactId>link-rest-swagger-codefirst</artifactId>
+                        <version>${project.version}</version>
+                    </dependency>
+                    <dependency>
+                        <groupId>com.nhl.link.rest</groupId>
+                        <artifactId>link-rest</artifactId>
+                        <type>test-jar</type>
+                        <version>${project.version}</version>
+                    </dependency>
+                </dependencies>
+            </plugin>
+
+        </plugins>
+    </build>
+
+</project>

--- a/link-rest-swagger-codefirst-test/pom.xml
+++ b/link-rest-swagger-codefirst-test/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>com.nhl.link.rest</groupId>
         <artifactId>link-rest-parent</artifactId>
-        <version>2.13-SNAPSHOT</version>
+        <version>2.14-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
 

--- a/link-rest-swagger-codefirst/pom.xml
+++ b/link-rest-swagger-codefirst/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>com.nhl.link.rest</groupId>
 		<artifactId>link-rest-parent</artifactId>
-		<version>2.13-SNAPSHOT</version>
+		<version>2.14-SNAPSHOT</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/link-rest-swagger-codefirst/pom.xml
+++ b/link-rest-swagger-codefirst/pom.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>com.nhl.link.rest</groupId>
+		<artifactId>link-rest-parent</artifactId>
+		<version>2.13-SNAPSHOT</version>
+		<relativePath>../pom.xml</relativePath>
+	</parent>
+
+    <groupId>com.nhl.link.rest.swagger</groupId>
+	<artifactId>link-rest-swagger-codefirst</artifactId>
+	<name>link-rest-swagger-codefirst: Swagger Code-First approach for LinkRest</name>
+	<description>Swagger Code-First approach for LinkRest</description>
+    <packaging>maven-plugin</packaging>
+
+
+    <properties>
+        <!-- Plugin versions -->
+        <maven-release-plugin-version>2.5.3</maven-release-plugin-version>
+        <plexus-component-metadata-version>1.5.5</plexus-component-metadata-version>
+        <maven-compiler-plugin-version>2.3.2</maven-compiler-plugin-version>
+        <maven-plugin-plugin-version>3.5</maven-plugin-plugin-version>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-release-plugin</artifactId>
+                <version>${maven-release-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-component-metadata</artifactId>
+                <version>${plexus-component-metadata-version}</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate-metadata</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin-version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-plugin-plugin</artifactId>
+                <version>${maven-plugin-plugin-version}</version>
+                <configuration>
+                    <!-- see http://jira.codehaus.org/browse/MNG-5346 -->
+                    <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>mojo-descriptor</id>
+                        <goals>
+                            <goal>descriptor</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+
+	<dependencies>
+
+		<!-- required runtime dependencies -->
+		<dependency>
+			<groupId>com.nhl.link.rest</groupId>
+			<artifactId>link-rest</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+
+		<dependency>
+			<groupId>io.swagger.core.v3</groupId>
+			<artifactId>swagger-jaxrs2</artifactId>
+			<scope>compile</scope>
+			<version>${swagger-version}</version>
+		</dependency>
+        <dependency>
+            <groupId>org.apache.maven.plugin-tools</groupId>
+            <artifactId>maven-plugin-annotations</artifactId>
+            <version>3.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-plugin-api</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.maven</groupId>
+            <artifactId>maven-core</artifactId>
+            <version>3.5.0</version>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/CayenneDataObjectConverter.java
+++ b/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/CayenneDataObjectConverter.java
@@ -1,0 +1,50 @@
+package com.nhl.link.rest.swagger.codefirst;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.swagger.v3.core.converter.AnnotatedType;
+import io.swagger.v3.core.converter.ModelConverter;
+import io.swagger.v3.core.converter.ModelConverterContext;
+import io.swagger.v3.core.jackson.AbstractModelConverter;
+import io.swagger.v3.oas.models.media.Schema;
+
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Set;
+
+/**
+ * @author vyarmolovich
+ * 8/28/18
+ */
+public class CayenneDataObjectConverter extends AbstractModelConverter {
+
+    static final Set<String> ignored = new HashSet();
+
+    static {
+        // ignores cayenne package to generate clean data model
+        ignored.add("org.apache.cayenne");
+    }
+
+    public CayenneDataObjectConverter(ObjectMapper mapper) {
+        super(mapper);
+    }
+
+    @Override
+    public Schema resolve(AnnotatedType type, ModelConverterContext context, Iterator<ModelConverter> chain) {
+        if (isIgnored(type.getType().getTypeName())) {
+            return null;
+        }
+        return super.resolve(type, context, chain);
+    }
+
+    protected boolean isIgnored(String className) {
+        if (className != null) {
+            for (String name : ignored) {
+                if (className.contains(name)) {
+                    return true;
+                }
+            }
+            return false;
+        }
+        return true;
+    }
+}

--- a/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ComponentSource.java
+++ b/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ComponentSource.java
@@ -1,0 +1,84 @@
+package com.nhl.link.rest.swagger.codefirst.mavenplugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.Set;
+
+/**
+ * @author vyarmolovich
+ * 8/13/18
+ */
+public class ComponentSource {
+
+    /**
+     * List of api Parameter classes that contains annotations to generate .yaml/.json files.
+     *
+     */
+    @Parameter
+    private Set<String> srcParameters;
+
+    /**
+     * List of domain Model classes that contains annotations to generate .yaml/.json files.
+     *
+     */
+    @Parameter
+    private Set<String> srcSchemas;
+
+    /**
+     * Scanner class to read annotated component classes
+     */
+    @Parameter String scanner;
+
+    /**
+     * Name (path) of generated file
+     */
+    @Parameter
+    private String outputName;
+
+    /**
+     * Format of generated file. Maybe .json and/or .yaml
+     */
+    @Parameter
+    private String outputFormats;
+
+
+    public String getOutputName() {
+        return outputName;
+    }
+
+    public void setOutputName(String outputName) {
+        this.outputName = outputName;
+    }
+
+    public String getOutputFormats() {
+        return outputFormats;
+    }
+
+    public void setOutputFormats(String outputFormats) {
+        this.outputFormats = outputFormats;
+    }
+
+    public Set<String> getSrcParameters() {
+        return srcParameters;
+    }
+
+    public void setSrcParameters(Set<String> srcParameters) {
+        this.srcParameters = srcParameters;
+    }
+
+    public Set<String> getSrcSchemas() {
+        return srcSchemas;
+    }
+
+    public void setSrcSchemas(Set<String> srcSchemas) {
+        this.srcSchemas = srcSchemas;
+    }
+
+    public String getScanner() {
+        return scanner;
+    }
+
+    public void setScanner(String scanner) {
+        this.scanner = scanner;
+    }
+}

--- a/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ProtocolMojo.java
+++ b/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ProtocolMojo.java
@@ -1,0 +1,213 @@
+package com.nhl.link.rest.swagger.codefirst.mavenplugin;
+
+import com.nhl.link.rest.swagger.codefirst.CayenneDataObjectConverter;
+import io.swagger.v3.core.converter.ModelConverters;
+import io.swagger.v3.core.util.Json;
+import io.swagger.v3.core.util.Yaml;
+import io.swagger.v3.jaxrs2.Reader;
+import io.swagger.v3.oas.integration.GenericOpenApiContextBuilder;
+import io.swagger.v3.oas.integration.GenericOpenApiScanner;
+import io.swagger.v3.oas.integration.OpenApiConfigurationException;
+import io.swagger.v3.oas.integration.SwaggerConfiguration;
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.media.Schema;
+import org.apache.maven.plugin.AbstractMojo;
+import org.apache.maven.plugin.MojoExecutionException;
+import org.apache.maven.plugin.MojoFailureException;
+import org.apache.maven.plugins.annotations.LifecyclePhase;
+import org.apache.maven.plugins.annotations.Mojo;
+import org.apache.maven.plugins.annotations.Parameter;
+import org.apache.maven.project.MavenProject;
+
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * @author vyarmolovich
+ * 8/13/18
+ */
+
+@Mojo(name = "generate", defaultPhase = LifecyclePhase.COMPILE, threadSafe = true)
+public class ProtocolMojo extends AbstractMojo {
+
+    @Parameter
+    private Info info;
+
+    /**
+     * A list of ResourceSource.
+     */
+    @Parameter
+    private List<ResourceSource> resourceSources;
+
+    /**
+     * A list of ComponentSource.
+     */
+    @Parameter
+    private List<ComponentSource> componentSources;
+
+
+    @Parameter(defaultValue = "${project}", readonly = true)
+    private MavenProject project;
+
+
+
+    @Override
+    public void execute() throws MojoExecutionException, MojoFailureException {
+
+        // generates .json and .yaml both api resources and components definition
+        if (resourceSources != null) {
+            for (ResourceSource resourceSource : resourceSources) {
+
+                OpenAPI openAPI = processResource(resourceSource);
+
+                String outputName = resourceSource.getOutputName();
+                if (outputName != null && !outputName.isEmpty()) {
+                    try {
+                        // writes result as both .json and .yaml
+                        Files.write(Paths.get(outputName + ".json"),
+                                Json.pretty().writeValueAsBytes(openAPI));
+
+                        Files.write(Paths.get(outputName+ ".yaml"),
+                                Yaml.pretty().writeValueAsBytes(openAPI));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+
+        // generates components definition, if defined
+        if (componentSources != null) {
+            for (ComponentSource componentSource : componentSources) {
+
+                OpenAPI openAPI = processComponent(componentSource);
+
+                String outputName = componentSource.getOutputName();
+                if (outputName != null && !outputName.isEmpty()) {
+                    try {
+                        // writes result as both .json and .yaml
+                        Files.write(Paths.get(outputName + ".json"),
+                                Json.pretty().writeValueAsBytes(openAPI));
+
+                        Files.write(Paths.get(outputName + ".yaml"),
+                                Yaml.pretty().writeValueAsBytes(openAPI));
+                    } catch (Exception e) {
+                        e.printStackTrace();
+                    }
+                }
+            }
+        }
+
+        ComponentSource componentSource = componentSources.iterator().next();
+
+    }
+
+    private OpenAPI processResource(ResourceSource resourceSource) throws MojoFailureException {
+
+        validateResourceSource(resourceSource);
+
+        OpenAPI oas = new OpenAPI();
+        oas.info(info);
+
+        SwaggerConfiguration oasConfig = new SwaggerConfiguration()
+                .openAPI(oas)
+                .prettyPrint(true)
+                .resourceClasses(resourceSource.getSrcClasses())
+                .resourcePackages(resourceSource.getSrcPackages())
+                .readerClass(Reader.class.getName());
+
+        try {
+            OpenAPI openAPI = new GenericOpenApiContextBuilder()
+                    .openApiConfiguration(oasConfig)
+                    .buildContext(true)
+                    .read();
+
+            System.out.println("###### ");
+
+            Json.prettyPrint(openAPI);
+
+            return openAPI;
+
+        } catch (OpenApiConfigurationException e) {
+            throw new RuntimeException(e.getMessage(), e);
+        }
+    }
+
+    private OpenAPI processComponent(ComponentSource componentSource) throws MojoFailureException {
+        validateComponentSource(componentSource);
+
+        Components components = new Components();
+
+        OpenAPI openAPI = new OpenAPI();
+        openAPI.info(info);
+
+        // scan and parse Parameters
+        SwaggerConfiguration oasConfigParameters = new SwaggerConfiguration()
+                .openAPI(openAPI)
+                .prettyPrint(true)
+                .resourceClasses(componentSource.getSrcParameters());
+
+        GenericOpenApiScanner scannerParameters = new GenericOpenApiScanner();
+        scannerParameters.setConfiguration(oasConfigParameters);
+
+
+        for (Class cls : scannerParameters.classes()) {
+            Map<String, Schema> parameters = ModelConverters.getInstance().readAll(cls);
+            for (String key : parameters.keySet()) {
+
+                io.swagger.v3.oas.models.parameters.Parameter parameter =
+                        new io.swagger.v3.oas.models.parameters.Parameter()
+                                .schema(parameters.get(key));
+
+                components.addParameters(key, parameter);
+            }
+        }
+
+        // scan and parse Schemas
+        SwaggerConfiguration oasConfigSchemas = new SwaggerConfiguration()
+                .openAPI(openAPI)
+                .prettyPrint(true)
+                .resourceClasses(componentSource.getSrcSchemas());
+
+        GenericOpenApiScanner scannerSchemas = new GenericOpenApiScanner();
+        scannerSchemas.setConfiguration(oasConfigSchemas);
+
+        ModelConverters modelConverters = ModelConverters.getInstance();
+        modelConverters.addConverter(new CayenneDataObjectConverter(Json.mapper()));
+
+        for (Class cls : scannerSchemas.classes()) {
+            Map<String, Schema> schemas = modelConverters.readAll(cls);
+            for (String key : schemas.keySet()) {
+                components.addSchemas(key, schemas.get(key));
+            }
+        }
+
+        openAPI.components(components);
+
+        return openAPI;
+    }
+
+    private void validateResourceSource(ResourceSource resourceSource) throws MojoFailureException {
+
+//        if ((componentSource.getSrcParameters() == null || componentSource.getSrcParameters().isEmpty())
+//                && (componentSource.getSrcSchemas() == null || componentSource.getSrcSchemas().isEmpty())) {
+//
+//            throw new MojoFailureException("Must be configured at least one scrParameter element or scrSchema element");
+//        }
+    }
+
+    private void validateComponentSource(ComponentSource componentSource) throws MojoFailureException {
+
+        if ((componentSource.getSrcParameters() == null || componentSource.getSrcParameters().isEmpty())
+                && (componentSource.getSrcSchemas() == null || componentSource.getSrcSchemas().isEmpty())) {
+
+            throw new MojoFailureException("Must be configured at least one scrParameter element or scrSchema element");
+        }
+    }
+
+}

--- a/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ProtocolMojo.java
+++ b/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ProtocolMojo.java
@@ -127,10 +127,6 @@ public class ProtocolMojo extends AbstractMojo {
                     .buildContext(true)
                     .read();
 
-            System.out.println("###### ");
-
-            Json.prettyPrint(openAPI);
-
             return openAPI;
 
         } catch (OpenApiConfigurationException e) {
@@ -194,11 +190,7 @@ public class ProtocolMojo extends AbstractMojo {
 
     private void validateResourceSource(ResourceSource resourceSource) throws MojoFailureException {
 
-//        if ((componentSource.getSrcParameters() == null || componentSource.getSrcParameters().isEmpty())
-//                && (componentSource.getSrcSchemas() == null || componentSource.getSrcSchemas().isEmpty())) {
-//
-//            throw new MojoFailureException("Must be configured at least one scrParameter element or scrSchema element");
-//        }
+        //Todo: Implement validation of resource source items.
     }
 
     private void validateComponentSource(ComponentSource componentSource) throws MojoFailureException {

--- a/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ResourceSource.java
+++ b/link-rest-swagger-codefirst/src/main/java/com/nhl/link/rest/swagger/codefirst/mavenplugin/ResourceSource.java
@@ -1,0 +1,70 @@
+package com.nhl.link.rest.swagger.codefirst.mavenplugin;
+
+import org.apache.maven.plugins.annotations.Parameter;
+
+import java.util.Set;
+
+/**
+ * @author vyarmolovich
+ * 8/20/18
+ */
+public class ResourceSource {
+
+    /**
+     * List of java classes that contains swagger annotations to generate .yaml/.json files.
+     *
+     */
+    @Parameter
+    private Set<String> srcClasses;
+
+    /**
+     * List of java packages that contains swagger annotations to generate .yaml/.json files.
+     *
+     */
+    @Parameter
+    private Set<String> srcPackages;
+
+    /**
+     * Name (path) of generated file
+     */
+    @Parameter
+    private String outputName;
+
+    /**
+     * Format of generated file. Maybe .json and/or .yaml
+     */
+    @Parameter
+    private String outputFormats;
+
+    public Set<String> getSrcClasses() {
+        return srcClasses;
+    }
+
+    public void setSrcClasses(Set<String> srcClasses) {
+        this.srcClasses = srcClasses;
+    }
+
+    public Set<String> getSrcPackages() {
+        return srcPackages;
+    }
+
+    public void setSrcPackages(Set<String> srcPackages) {
+        this.srcPackages = srcPackages;
+    }
+
+    public String getOutputName() {
+        return outputName;
+    }
+
+    public void setOutputName(String outputName) {
+        this.outputName = outputName;
+    }
+
+    public String getOutputFormats() {
+        return outputFormats;
+    }
+
+    public void setOutputFormats(String outputFormats) {
+        this.outputFormats = outputFormats;
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
         <module>link-rest-bom</module>
         <module>link-rest-docs</module>
         <module>link-rest-legacy-date-encoders</module>
+        <module>link-rest-swagger-codefirst</module>
+        <module>link-rest-swagger-codefirst-test</module>
     </modules>
 
     <properties>
@@ -35,7 +37,8 @@
         <cayenne-version>4.0.RC1</cayenne-version>
         <jersey-version>2.27</jersey-version>
         <jaxrs-version>2.1</jaxrs-version>
-        <jackson-version>2.6.4</jackson-version>
+        <jackson-version>2.9.1</jackson-version>
+        <swagger-version>2.0.1</swagger-version>
     </properties>
 
     <url>https://github.com/nhl/link-rest</url>


### PR DESCRIPTION
This maven plugin uses swagger converters to generate .yaml and .json definition from the following sources:
- resourceSources: classes or packages that contains REST API implementation. 
- componentSources:
-- parameters: link rest protocol parameters classes (Sort, Include, Exclude, etc.).
-- schemas:  protocol models classes (CayenneDataObject)

Example of maven plugin configuration is provided in **link-rest-swagger-codefirst-test** module.
To run this example  use **mvn clean install** command.