### PR TITLE
Bump to the latest version of openapi-generator (v5.2.0)

### DIFF
--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E1Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E1Resource.java
@@ -20,7 +20,7 @@ public class E1Resource {
 
     @DELETE
     @Path("/v1/e1/{id}")
-    public SimpleResponse delete(@PathParam("id") Integer id) {
+    public SimpleResponse deleteE1(@PathParam("id") Integer id) {
 
         return Ag.delete(E1.class, config)
                  .id(id)
@@ -30,7 +30,7 @@ public class E1Resource {
     @GET
     @Path("/v1/e1")
     @Produces({ "application/json" })
-    public DataResponse<E1> getAll(@QueryParam("limit") Integer limit) {
+    public DataResponse<E1> getAllE1(@QueryParam("limit") Integer limit) {
 
         AgRequest agRequest = Ag.request(config)
                 .limit(limit)
@@ -44,7 +44,7 @@ public class E1Resource {
     @GET
     @Path("/v1/e1/{id}")
     @Produces({ "application/json" })
-        public DataResponse<E1> getOne(@PathParam("id") Integer id) {
+        public DataResponse<E1> getOneE1(@PathParam("id") Integer id) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E20Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E20Resource.java
@@ -21,7 +21,7 @@ public class E20Resource {
     @POST
     @Path("/v1/e20")
     @Consumes({ "application/json" })
-    public DataResponse<E20> create(String e20, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E20> createE20(String E20, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addExcludes(excludes)
@@ -29,12 +29,12 @@ public class E20Resource {
 
         return Ag.create(E20.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e20);
+                 .syncAndSelect(E20);
     }
 
     @DELETE
     @Path("/v1/e20/{name}")
-    public SimpleResponse deleteByName(@PathParam("name") String name) {
+    public SimpleResponse deleteE20ByName(@PathParam("name") String name) {
 
         return Ag.delete(E20.class, config)
                  .id(name)
@@ -44,7 +44,7 @@ public class E20Resource {
     @GET
     @Path("/v1/e20/{name}")
     @Produces({ "application/json" })
-        public DataResponse<E20> getOneByName(@PathParam("name") String name, @QueryParam("exclude") List<String> excludes) {
+        public DataResponse<E20> getOneE20ByName(@PathParam("name") String name, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addExcludes(excludes)
@@ -59,7 +59,7 @@ public class E20Resource {
     @PUT
     @Path("/v1/e20/{name}")
     @Consumes({ "application/json" })
-    public DataResponse<E20> updateByName(@PathParam("name") String name, String e20) {
+    public DataResponse<E20> updateE20ByName(@PathParam("name") String name, String E20) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
@@ -67,7 +67,7 @@ public class E20Resource {
         return Ag.idempotentCreateOrUpdate(E20.class, config)
                  .id(name)
                  .request(agRequest)
-                 .syncAndSelect(e20);
+                 .syncAndSelect(E20);
     }
 
 }

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E21Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E21Resource.java
@@ -21,7 +21,7 @@ public class E21Resource {
     @POST
     @Path("/v1/e21")
     @Consumes({ "application/json" })
-    public DataResponse<E21> create(String e21, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E21> createE21(String E21, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addExcludes(excludes)
@@ -29,15 +29,15 @@ public class E21Resource {
 
         return Ag.create(E21.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e21);
+                 .syncAndSelect(E21);
     }
 
     @DELETE
     @Path("/v1/e21")
-    public SimpleResponse deleteByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age) {
+    public SimpleResponse deleteE21ByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age) {
         Map<String, Object> id = new HashMap<>();
-        id.put("name", name);
         id.put("age", age);
+        id.put("name", name);
 
         return Ag.delete(E21.class, config)
                  .id(id)
@@ -47,11 +47,11 @@ public class E21Resource {
     @GET
     @Path("/v1/e21")
     @Produces({ "application/json" })
-    public DataResponse<E21> getOneByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E21> getOneE21ByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age, @QueryParam("exclude") List<String> excludes) {
 
         Map<String, Object> id = new HashMap<>();
-        id.put("name", name);
         id.put("age", age);
+        id.put("name", name);
 
         AgRequest agRequest = Ag.request(config)
                 .addExcludes(excludes)
@@ -66,11 +66,11 @@ public class E21Resource {
     @PUT
     @Path("/v1/e21")
     @Consumes({ "application/json" })
-    public DataResponse<E21> updateByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age, String e21) {
+    public DataResponse<E21> updateE21ByCompoundId(@QueryParam("name") String name, @QueryParam("age") Integer age, String E21) {
 
         Map<String, Object> id = new HashMap<>();
-                id.put("name", name);
                 id.put("age", age);
+                id.put("name", name);
 
 
         AgRequest agRequest = Ag.request(config)
@@ -79,7 +79,7 @@ public class E21Resource {
         return Ag.idempotentCreateOrUpdate(E21.class, config)
                  .id(id)
                  .request(agRequest)
-                 .syncAndSelect(e21);
+                 .syncAndSelect(E21);
     }
 
 }

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E2Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E2Resource.java
@@ -22,7 +22,7 @@ public class E2Resource {
     @POST
     @Path("/v1/e2")
     @Consumes({ "application/json" })
-    public DataResponse<E2> create(String e2, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E2> createE2(String E2, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -31,13 +31,13 @@ public class E2Resource {
 
         return Ag.create(E2.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e2);
+                 .syncAndSelect(E2);
     }
 
     @POST
     @Path("/v1/e2/{id}/e3s")
     @Consumes({ "application/json" })
-    public DataResponse<E3> createE3sViaE2(@PathParam("id") Integer id, String e3) {
+    public DataResponse<E3> createE3sViaE2(@PathParam("id") Integer id, String E3) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
@@ -45,7 +45,7 @@ public class E2Resource {
         return Ag.createOrUpdate(E3.class, config)
                  .parent(E2.class, id, "e3s")
                  .request(agRequest)
-                 .syncAndSelect(e3);
+                 .syncAndSelect(E3);
     }
 
     @DELETE
@@ -67,7 +67,7 @@ public class E2Resource {
     @GET
     @Path("/v1/e2")
     @Produces({ "application/json" })
-    public DataResponse<E2> getAll(@QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes, @QueryParam("exp") String exp) {
+    public DataResponse<E2> getAllE2(@QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes, @QueryParam("exp") String exp) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -99,7 +99,7 @@ public class E2Resource {
     @GET
     @Path("/v1/e2/{id}")
     @Produces({ "application/json" })
-        public DataResponse<E2> getOne(@PathParam("id") Integer id, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
+        public DataResponse<E2> getOneE2(@PathParam("id") Integer id, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -115,7 +115,7 @@ public class E2Resource {
     @GET
     @Path("/v1/e2/{id}/e3s")
     @Produces({ "application/json" })
-        public DataResponse<E3> getOneToMany(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
+        public DataResponse<E3> getOneE2ToManyE3(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -130,7 +130,7 @@ public class E2Resource {
     @PUT
     @Path("/v1/e2/{id}")
     @Consumes({ "application/json" })
-    public DataResponse<E2> update(@PathParam("id") Integer id, String e2, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E2> updateE2(@PathParam("id") Integer id, String E2, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -140,13 +140,13 @@ public class E2Resource {
         return Ag.idempotentCreateOrUpdate(E2.class, config)
                  .id(id)
                  .request(agRequest)
-                 .syncAndSelect(e2);
+                 .syncAndSelect(E2);
     }
 
     @PUT
     @Path("/v1/e2/{id}/e3s")
     @Consumes({ "application/json" })
-    public DataResponse<E3> updateE3sViaE2(@PathParam("id") Integer id, String e3) {
+    public DataResponse<E3> updateE3sViaE2(@PathParam("id") Integer id, String E3) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
@@ -154,7 +154,7 @@ public class E2Resource {
         return Ag.idempotentCreateOrUpdate(E3.class, config)
                  .parent(E2.class, id, "e3s")
                  .request(agRequest)
-                 .syncAndSelect(e3);
+                 .syncAndSelect(E3);
     }
 
 }

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E3Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E3Resource.java
@@ -22,7 +22,7 @@ public class E3Resource {
     @POST
     @Path("/v1/e3")
     @Consumes({ "application/json" })
-    public DataResponse<E3> create(String e3, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E3> createE3(String E3, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -31,7 +31,7 @@ public class E3Resource {
 
         return Ag.create(E3.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e3);
+                 .syncAndSelect(E3);
     }
 
     @DELETE
@@ -44,7 +44,7 @@ public class E3Resource {
 
     @DELETE
     @Path("/v1/e3/{id}/e2/{tid}")
-    public SimpleResponse deleteE2ViaE3_1(@PathParam("id") Integer id, @PathParam("tid") Integer tid) {
+    public SimpleResponse deleteE2ViaE3WithTid(@PathParam("id") Integer id, @PathParam("tid") Integer tid) {
 
         return Ag.service(config)
                  .unrelate(E3.class, id, "e2", tid);
@@ -53,7 +53,7 @@ public class E3Resource {
     @GET
     @Path("/v1/e3")
     @Produces({ "application/json" })
-    public DataResponse<E3> getAll(@QueryParam("sort") String sort, @QueryParam("dir") String dir, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes, @QueryParam("limit") Integer limit, @QueryParam("start") Integer start, @QueryParam("mapBy") String mapBy, @QueryParam("exp") String exp) {
+    public DataResponse<E3> getAllE3(@QueryParam("sort") String sort, @QueryParam("dir") String dir, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes, @QueryParam("limit") Integer limit, @QueryParam("start") Integer start, @QueryParam("mapBy") String mapBy, @QueryParam("exp") String exp) {
 
         AgRequest agRequest = Ag.request(config)
                 .addOrdering(sort, dir)
@@ -73,7 +73,7 @@ public class E3Resource {
     @GET
     @Path("/v1/e3/{id}")
     @Produces({ "application/json" })
-        public DataResponse<E3> getOne(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
+        public DataResponse<E3> getOneE3(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -88,7 +88,7 @@ public class E3Resource {
     @GET
     @Path("/v1/e3/{id}/e2")
     @Produces({ "application/json" })
-        public DataResponse<E2> getOneByOne(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
+        public DataResponse<E2> getOneE3ByOneE2(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -101,23 +101,9 @@ public class E3Resource {
     }
 
     @PUT
-    @Path("/v1/e3/{id}")
-    @Consumes({ "application/json" })
-    public DataResponse<E3> update(@PathParam("id") Integer id, String e3) {
-
-        AgRequest agRequest = Ag.request(config)
-                .build();
-
-        return Ag.idempotentCreateOrUpdate(E3.class, config)
-                 .id(id)
-                 .request(agRequest)
-                 .syncAndSelect(e3);
-    }
-
-    @PUT
     @Path("/v1/e3")
     @Consumes({ "application/json" })
-    public DataResponse<E3> updateAll(String e3, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
+    public DataResponse<E3> updateAllE3(String E3, @QueryParam("include") List<String> includes, @QueryParam("exclude") List<String> excludes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -126,13 +112,13 @@ public class E3Resource {
 
         return Ag.idempotentCreateOrUpdate(E3.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e3);
+                 .syncAndSelect(E3);
     }
 
     @PUT
     @Path("/v1/e3/{id}/e2/{tid}")
     @Consumes({ "application/json" })
-    public DataResponse<E2> updateE2ViaE3(@PathParam("id") Integer id, @PathParam("tid") Integer tid, String e2) {
+    public DataResponse<E2> updateE2ViaE3(@PathParam("id") Integer id, @PathParam("tid") Integer tid, String E2) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
@@ -141,7 +127,21 @@ public class E3Resource {
                  .id(tid)
                  .parent(E3.class, id, "e2")
                  .request(agRequest)
-                 .syncAndSelect(e2);
+                 .syncAndSelect(E2);
+    }
+
+    @PUT
+    @Path("/v1/e3/{id}")
+    @Consumes({ "application/json" })
+    public DataResponse<E3> updateE3(@PathParam("id") Integer id, String E3) {
+
+        AgRequest agRequest = Ag.request(config)
+                .build();
+
+        return Ag.idempotentCreateOrUpdate(E3.class, config)
+                 .id(id)
+                 .request(agRequest)
+                 .syncAndSelect(E3);
     }
 
 }

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E4Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E4Resource.java
@@ -21,19 +21,19 @@ public class E4Resource {
     @POST
     @Path("/v1/e4")
     @Consumes({ "application/json" })
-    public DataResponse<E4> create(String e4) {
+    public DataResponse<E4> createE4(String E4) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
 
         return Ag.create(E4.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e4);
+                 .syncAndSelect(E4);
     }
 
     @DELETE
     @Path("/v1/e4/{id}")
-    public SimpleResponse delete(@PathParam("id") Integer id) {
+    public SimpleResponse deleteE4(@PathParam("id") Integer id) {
 
         return Ag.delete(E4.class, config)
                  .id(id)
@@ -43,7 +43,7 @@ public class E4Resource {
     @GET
     @Path("/v1/e4")
     @Produces({ "application/json" })
-    public DataResponse<E4> getAll(@QueryParam("limit") Integer limit, @QueryParam("sort") String sort, @QueryParam("include") List<String> includes, @QueryParam("mapBy") String mapBy) {
+    public DataResponse<E4> getAllE4(@QueryParam("limit") Integer limit, @QueryParam("sort") String sort, @QueryParam("include") List<String> includes, @QueryParam("mapBy") String mapBy) {
 
         AgRequest agRequest = Ag.request(config)
                 .limit(limit)
@@ -60,7 +60,7 @@ public class E4Resource {
     @GET
     @Path("/v1/e4/{id}")
     @Produces({ "application/json" })
-        public DataResponse<E4> getOne(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
+        public DataResponse<E4> getOneE4(@PathParam("id") Integer id, @QueryParam("include") List<String> includes) {
 
         AgRequest agRequest = Ag.request(config)
                 .addIncludes(includes)
@@ -75,7 +75,7 @@ public class E4Resource {
     @PUT
     @Path("/v1/e4/{id}")
     @Consumes({ "application/json" })
-    public DataResponse<E4> update(@PathParam("id") Integer id, String e4) {
+    public DataResponse<E4> updateE4(@PathParam("id") Integer id, String E4) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
@@ -83,7 +83,7 @@ public class E4Resource {
         return Ag.idempotentCreateOrUpdate(E4.class, config)
                  .id(id)
                  .request(agRequest)
-                 .syncAndSelect(e4);
+                 .syncAndSelect(E4);
     }
 
 }

--- a/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E5Resource.java
+++ b/agrest-openapi-designfirst-test/src/test/java/io/agrest/swagger/api/v1/service/E5Resource.java
@@ -21,20 +21,20 @@ public class E5Resource {
     @POST
     @Path("/v1/e5")
     @Consumes({ "application/json" })
-    public DataResponse<E5> create(String e5) {
+    public DataResponse<E5> createE5(String E5) {
 
         AgRequest agRequest = Ag.request(config)
                 .build();
 
         return Ag.create(E5.class, config)
                  .request(agRequest)
-                 .syncAndSelect(e5);
+                 .syncAndSelect(E5);
     }
 
     @GET
     @Path("/v1/e5")
     @Produces({ "application/json" })
-    public DataResponse<E5> getAll() {
+    public DataResponse<E5> getAllE5() {
 
         AgRequest agRequest = Ag.request(config)
                 .build();

--- a/agrest-openapi-designfirst-test/src/test/resources/api.yaml
+++ b/agrest-openapi-designfirst-test/src/test/resources/api.yaml
@@ -28,7 +28,7 @@ paths:
   /e1:
     get:
       summary: Get all E1s
-      operationId: getAll
+      operationId: getAllE1
       tags:
         - E1
       parameters:
@@ -48,7 +48,7 @@ paths:
   /e1/{id}:
     get:
       description: Returns a E1
-      operationId: getOne
+      operationId: getOneE1
       tags:
         - E1
       parameters:
@@ -70,7 +70,7 @@ paths:
           description: Unexpected error
     delete:
       description: Deletes a E1 item based on the ID supplied
-      operationId: delete
+      operationId: deleteE1
       tags:
         - E1
       parameters:
@@ -93,7 +93,7 @@ paths:
       - $ref: '../resources/protocol.yaml#/components/queryParams/Excludes'
     get:
       summary: Get all E2s
-      operationId: getAll
+      operationId: getAllE2
       tags:
         - E2
       parameters:
@@ -113,7 +113,7 @@ paths:
       tags:
         - E2
       summary: Creates E2
-      operationId: create
+      operationId: createE2
       requestBody:
         $ref: "#/components/requestBodies/E2"
       responses:
@@ -123,7 +123,7 @@ paths:
   /e2/{id}:
     get:
       description: Returns a E2
-      operationId: getOne
+      operationId: getOneE2
       tags:
         - E2
       parameters:
@@ -149,7 +149,7 @@ paths:
       tags:
         - E2
       summary: Updates E2
-      operationId: update
+      operationId: updateE2
       requestBody:
         $ref: "#/components/requestBodies/E2"
       parameters:
@@ -169,7 +169,7 @@ paths:
   /e2/{id}/e3s:
     get:
       description: Returns E3s related to E2
-      operationId: getOneToMany
+      operationId: getOneE2ToManyE3
       tags:
         - E2
         - E3
@@ -299,7 +299,7 @@ paths:
       tags:
         - E3
       summary: Creates E3
-      operationId: create
+      operationId: createE3
       requestBody:
         $ref: "#/components/requestBodies/E3"
       parameters:
@@ -310,7 +310,7 @@ paths:
           description: successful operation
     get:
       summary: Get all E3s
-      operationId: getAll
+      operationId: getAllE3
       tags:
         - E3
       parameters:
@@ -337,7 +337,7 @@ paths:
       tags:
         - E3
       summary: Updates E3
-      operationId: updateAll
+      operationId: updateAllE3
       requestBody:
         $ref: "#/components/requestBodies/E3"
       parameters:
@@ -350,7 +350,7 @@ paths:
   /e3/{id}:
     get:
       description: Returns a E3
-      operationId: getOne
+      operationId: getOneE3
       tags:
         - E3
       parameters:
@@ -375,7 +375,7 @@ paths:
       tags:
         - E3
       summary: Updates E3
-      operationId: update
+      operationId: updateE3
       requestBody:
         $ref: "#/components/requestBodies/E3"
       parameters:
@@ -393,7 +393,7 @@ paths:
   /e3/{id}/e2:
     get:
       description: Returns a E2 related to E3
-      operationId: getOneByOne
+      operationId: getOneE3ByOneE2
       tags:
         - E3
         - E2
@@ -465,7 +465,7 @@ paths:
           description: successful operation
     delete:
       description: Deletes E2 Via E3
-      operationId: deleteE2ViaE3
+      operationId: deleteE2ViaE3WithTid
       tags:
         - E3
         - E2
@@ -481,7 +481,7 @@ paths:
       tags:
         - E4
       summary: Creates E4
-      operationId: create
+      operationId: createE4
       requestBody:
         $ref: "#/components/requestBodies/E4"
       responses:
@@ -489,7 +489,7 @@ paths:
           description: successful operation
     get:
       summary: Get all E4s
-      operationId: getAll
+      operationId: getAllE4
       tags:
         - E4
       parameters:
@@ -512,7 +512,7 @@ paths:
   /e4/{id}:
     get:
       description: Returns a E4
-      operationId: getOne
+      operationId: getOneE4
       tags:
         - E4
       parameters:
@@ -535,7 +535,7 @@ paths:
           description: Unexpected error
     delete:
       description: Deletes a E4 item based on the ID supplied
-      operationId: delete
+      operationId: deleteE4
       tags:
         - E4
       parameters:
@@ -555,7 +555,7 @@ paths:
       tags:
         - E4
       summary: Updates E4
-      operationId: update
+      operationId: updateE4
       requestBody:
         $ref: "#/components/requestBodies/E4"
       parameters:
@@ -573,7 +573,7 @@ paths:
   /e5:
     get:
       summary: Get all E5s
-      operationId: getAll
+      operationId: getAllE5
       tags:
         - E5
       responses:
@@ -591,7 +591,7 @@ paths:
       tags:
         - E5
       summary: Create E5
-      operationId: create
+      operationId: createE5
       requestBody:
         $ref: "#/components/requestBodies/E5"
       responses:
@@ -603,7 +603,7 @@ paths:
       tags:
         - E20
       summary: Create E20
-      operationId: create
+      operationId: createE20
       requestBody:
         $ref: "#/components/requestBodies/E20"
       parameters:
@@ -615,7 +615,7 @@ paths:
   /e20/{name}:
     get:
       description: Returns a E20 by natural ID
-      operationId: getOneByName
+      operationId: getOneE20ByName
       tags:
         - E20
       parameters:
@@ -637,7 +637,7 @@ paths:
           description: Unexpected error
     delete:
       description: Deletes a E20 item based on the Name supplied
-      operationId: deleteByName
+      operationId: deleteE20ByName
       tags:
         - E20
       parameters:
@@ -656,7 +656,7 @@ paths:
       tags:
         - E20
       summary: Updates E20
-      operationId: updateByName
+      operationId: updateE20ByName
       requestBody:
         $ref: "#/components/requestBodies/E20"
       parameters:
@@ -673,7 +673,7 @@ paths:
   /e21:
     get:
       description: Returns a E21 by natural ID
-      operationId: getOneByCompoundId
+      operationId: getOneE21ByCompoundId
       tags:
         - E21
       parameters:
@@ -702,7 +702,7 @@ paths:
           description: Unexpected error
     delete:
       description: Deletes a E21 item based on name and age
-      operationId: deleteByCompoundId
+      operationId: deleteE21ByCompoundId
       tags:
         - E21
       parameters:
@@ -728,7 +728,7 @@ paths:
       tags:
         - E21
       summary: Create E21
-      operationId: create
+      operationId: createE21
       requestBody:
         $ref: "#/components/requestBodies/E21"
       parameters:
@@ -740,7 +740,7 @@ paths:
       tags:
         - E21
       summary: Updates E21
-      operationId: updateByCompoundId
+      operationId: updateE21ByCompoundId
       requestBody:
         $ref: "#/components/requestBodies/E21"
       parameters:

--- a/agrest-openapi-designfirst/src/main/java/io/swagger/codegen/AgCodegenOperation.java
+++ b/agrest-openapi-designfirst/src/main/java/io/swagger/codegen/AgCodegenOperation.java
@@ -30,10 +30,9 @@ public class AgCodegenOperation extends CodegenOperation {
         this.returnTypeIsPrimitive = codegenOperation.returnTypeIsPrimitive;
         this.returnSimpleType = codegenOperation.returnSimpleType;
         this.subresourceOperation = codegenOperation.subresourceOperation;
-        this.isMapContainer = codegenOperation.isMapContainer;
-        this.isListContainer = codegenOperation.isListContainer;
+        this.isMap = codegenOperation.isMap;
+        this.isArray = codegenOperation.isArray;
         this.isMultipart = codegenOperation.isMultipart;
-        this.hasMore = codegenOperation.hasMore;
         this.isResponseBinary = codegenOperation.isResponseBinary;
         this.hasReference = codegenOperation.hasReference;
         this.isRestfulIndex = codegenOperation.isRestfulIndex;

--- a/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/api.mustache
+++ b/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/api.mustache
@@ -22,7 +22,7 @@ public class {{classname}} {
 {{#operations}}
 {{#operation}}
     @{{httpMethod}}
-    {{#subresourceOperation}}@Path("/{{version}}{{path}}"){{/subresourceOperation}}
+    {{#subresourceOperation}}@Path("/{{version}}{{commonPath}}{{path}}"){{/subresourceOperation}}{{^subresourceOperation}}@Path("/{{version}}{{commonPath}}{{path}}"){{/subresourceOperation}}
     {{#hasConsumes}}
     @Consumes({ {{#consumes}}"{{{mediaType}}}"{{#hasMore}}, {{/hasMore}}{{/consumes}} })
     {{/hasConsumes}}

--- a/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/delete.mustache
+++ b/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/delete.mustache
@@ -1,6 +1,6 @@
 {{#isRestfulDestroy}}
     {{#hasCompoundId}}
-public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
         Map<String, Object> id = new HashMap<>();
         {{#modelAttributes}}
             {{#isQueryParam}}
@@ -14,7 +14,7 @@ public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}
     }
     {{/hasCompoundId}}
     {{^hasCompoundId}}
-public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         return Ag.delete({{{returnType}}}.class, config)
                  .id({{#pathParams}}{{paramName}}{{/pathParams}})
@@ -23,14 +23,14 @@ public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}
     {{/hasCompoundId}}
 {{/isRestfulDestroy}}
 {{#isRestfulDestroyToMany}}
-public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         return Ag.service(config)
                  .unrelate({{returnType}}.class, {{#pathParams}}{{paramName}}{{/pathParams}}, "{{#modelRelations}}{{bodyParam.paramName}}{{/modelRelations}}");
     }
 {{/isRestfulDestroyToMany}}
 {{#isRestfulRelatedDestroy}}
-public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public SimpleResponse {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>headerParams}}{{>bodyParams}}{{>formParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         return Ag.service(config)
                  .unrelate({{returnType}}.class, {{#pathParams}}{{#-first}}{{paramName}}{{/-first}}{{/pathParams}}, "{{#modelRelations}}{{bodyParam.paramName}}{{/modelRelations}}", {{#pathParams}}{{#-last}}{{paramName}}{{/-last}}{{/pathParams}});

--- a/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/get.mustache
+++ b/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/get.mustache
@@ -1,6 +1,6 @@
 {{#isRestfulIndex}}
     {{#hasCompoundId}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         Map<String, Object> id = new HashMap<>();
         {{#modelAttributes}}
@@ -18,7 +18,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     }
     {{/hasCompoundId}}
     {{^hasCompoundId}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -29,7 +29,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     {{/hasCompoundId}}
 {{/isRestfulIndex}}
 {{#isRestfulShow}}
-    public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -40,7 +40,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     }
 {{/isRestfulShow}}
 {{#isRestfulIndexRelated}}
-    public DataResponse<{{#modelRelations}}{{returnType}}{{/modelRelations}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    public DataResponse<{{#modelRelations}}{{returnType}}{{/modelRelations}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -52,7 +52,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     }
 {{/isRestfulIndexRelated}}
 {{#isRestfulIndexToMany}}
-    public DataResponse<{{#modelRelations}}{{returnType}}{{/modelRelations}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+    public DataResponse<{{#modelRelations}}{{returnType}}{{/modelRelations}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 

--- a/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/post.mustache
+++ b/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/post.mustache
@@ -1,5 +1,5 @@
 {{#isRestfulCreate}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -9,7 +9,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     }
 {{/isRestfulCreate}}
 {{#isRestfulRelatedToManyCreate}}
-public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 

--- a/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/put.mustache
+++ b/agrest-openapi-designfirst/src/main/resources/JavaJaxRS/agrest/put.mustache
@@ -1,5 +1,5 @@
 {{#isRestfulUpdate}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -11,7 +11,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
 {{/isRestfulUpdate}}
 {{#isRestfulBulkUpdate}}
     {{#hasCompoundId}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         Map<String, Object> id = new HashMap<>();
         {{#modelAttributes}}
@@ -30,7 +30,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     }
     {{/hasCompoundId}}
     {{^hasCompoundId}}
-public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -41,7 +41,7 @@ public {{>returnTypes}} {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams
     {{/hasCompoundId}}
 {{/isRestfulBulkUpdate}}
 {{#isRestfulRelatedUpdate}}
-public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 
@@ -53,7 +53,7 @@ public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#
     }
 {{/isRestfulRelatedUpdate}}
 {{#isRestfulRelatedToManyUpdate}}
-public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{#hasMore}}, {{/hasMore}}{{/allParams}}) {
+public DataResponse<{{#bodyParams}}{{dataType}}{{/bodyParams}}> {{nickname}}({{#allParams}}{{>pathParams}}{{>queryParams}}{{>bodyParams}}{{^-last}}, {{/-last}}{{/allParams}}) {
 
         {{>protocolImpl}}
 

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <jersey-version>2.27</jersey-version>
         <jaxrs-version>2.1</jaxrs-version>
         <jackson-version>2.11.3</jackson-version>
-        <openapi-generator-version>3.0.2</openapi-generator-version>
+        <openapi-generator-version>5.2.0</openapi-generator-version>
         <bootique-version>2.0.B1</bootique-version>
         <junit5-version>5.7.0</junit5-version>
         <swagger.version>2.1.5</swagger.version>


### PR DESCRIPTION
- Bump to ` <openapi-generator-version>5.2.0</openapi-generator-version>`
- Add unique `operationId` in `api.yaml`
- Migrate the `io.swagger.codegen` classes and mustache template to be compliant with 5.2.0 version of openapi-generator
- Regenerate `io.agrest.swagger.api.v1.service` resources with `mv generate-sources`
- Fix case sensitive use of Map key with a TreeMap in `io.swagger.codegen.languages.AgServerCodegen` : may need a review